### PR TITLE
Fix specs on passing bad arguments to PushShipmentOrderDocumentJob

### DIFF
--- a/spec/jobs/solidus_quiet_logistics/outbound/push_shipment_order_document_job_spec.rb
+++ b/spec/jobs/solidus_quiet_logistics/outbound/push_shipment_order_document_job_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe SolidusQuietLogistics::Outbound::PushShipmentOrderDocumentJob do
   end
 
   context 'when perform is called with a bad argument' do
-    subject { -> { described_class.perform_now(bad_argument) } }
+    subject { described_class.perform_now(bad_argument) }
 
     let(:bad_argument) { 'Bad argument' }
 
     it 'raises an argument error exception' do
-      expect(subject).to raise_error(ArgumentError)
+      expect { subject }.to raise_error(ArgumentError)
     end
   end
 end


### PR DESCRIPTION
There's no need of using a proc since RSpec will take care of that when we are testing with raise_error matcher.